### PR TITLE
fix: missing folder(s) due to incomplete pagination

### DIFF
--- a/src/components/ItemBox.tsx
+++ b/src/components/ItemBox.tsx
@@ -79,7 +79,6 @@ const FileItem = ({ file, courseId }) => {
     }
   };
   const handleMouseEnter = () => {
-    console.log("Mouse entered");
     const element = textRef.current;
     if (element) {
       const overflowWidth = element.scrollWidth - 265;
@@ -89,7 +88,6 @@ const FileItem = ({ file, courseId }) => {
   };
   const handleMouseLeave = () => {
     const element = textRef.current;
-    console.log("Mouse leaves");
     if (element) {
       // Instantly reset the text position without animation
       element.style.transition = "transform 0s linear";


### PR DESCRIPTION
Incomplete fetch via Canvas API resulted in some folders and files missing from the file navigator. 

Some notable impact of this change would be slightly longer initial load time for courses with over 100+ files. There is no workaround to this for now. But the load time is still bearable